### PR TITLE
Enable useNativeDriver to improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following props can be used to modify the slot machine's style and/or behavi
 |__`renderTextContent`__|_Function_|Optional|`(char, index, range) => char`|Allows replacing the inner content of the Text element
 |__`renderContent`__|_Function_|Optional|`(char, index, range) => char`|Allows replacing the entire Text element with your own implementation
 |__`styles`__|_Object_|Optional|`{}`|Allows overriding each of the inner components (container, slotWrapper, slotInner, innerBorder, outerBorder, overlay, text)
-|__`useNativeDriver`__|_Boolean_|Optional|`true`|Enable use of NativeDriver on Animation. See https://facebook.github.io/react-native/docs/animations.html#using-the-native-driver
+|__`useNativeDriver`__|_Boolean_|Optional|`false`|Enable use of NativeDriver on Animation. See https://facebook.github.io/react-native/docs/animations.html#using-the-native-driver
 
 ## Methods
 #### `spinTo(text)`

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following props can be used to modify the slot machine's style and/or behavi
 |__`renderTextContent`__|_Function_|Optional|`(char, index, range) => char`|Allows replacing the inner content of the Text element
 |__`renderContent`__|_Function_|Optional|`(char, index, range) => char`|Allows replacing the entire Text element with your own implementation
 |__`styles`__|_Object_|Optional|`{}`|Allows overriding each of the inner components (container, slotWrapper, slotInner, innerBorder, outerBorder, overlay, text)
+|__`useNativeDriver`__|_Boolean_|Optional|`true`|Enable use of NativeDriver on Animation. See https://facebook.github.io/react-native/docs/animations.html#using-the-native-driver
 
 ## Methods
 #### `spinTo(text)`

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following props can be used to modify the slot machine's style and/or behavi
 |__`renderTextContent`__|_Function_|Optional|`(char, index, range) => char`|Allows replacing the inner content of the Text element
 |__`renderContent`__|_Function_|Optional|`(char, index, range) => char`|Allows replacing the entire Text element with your own implementation
 |__`styles`__|_Object_|Optional|`{}`|Allows overriding each of the inner components (container, slotWrapper, slotInner, innerBorder, outerBorder, overlay, text)
+|__`useNativeDriver`__|_Boolean_|Optional|`false`|Enable use of NativeDriver on Animation. See https://facebook.github.io/react-native/docs/animations.html#using-the-native-driver
 
 ## Methods
 #### `spinTo(text)`

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following props can be used to modify the slot machine's style and/or behavi
 |__`renderTextContent`__|_Function_|Optional|`(char, index, range) => char`|Allows replacing the inner content of the Text element
 |__`renderContent`__|_Function_|Optional|`(char, index, range) => char`|Allows replacing the entire Text element with your own implementation
 |__`styles`__|_Object_|Optional|`{}`|Allows overriding each of the inner components (container, slotWrapper, slotInner, innerBorder, outerBorder, overlay, text)
-|__`useNativeDriver`__|_Boolean_|Optional|`false`|Enable use of NativeDriver on Animation. See https://facebook.github.io/react-native/docs/animations.html#using-the-native-driver
+|__`useNativeDriver`__|_Boolean_|Optional|`true`|Enable use of NativeDriver on Animation. See https://facebook.github.io/react-native/docs/animations.html#using-the-native-driver
 
 ## Methods
 #### `spinTo(text)`

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ export default class SlotMachine extends Component {
             initialAnimation: true,
             styles: {},
             renderTextContent: (currentChar) => currentChar,
-			useNativeDriver: false,
+	    useNativeDriver: true,
         };
     }
 
@@ -232,7 +232,7 @@ export default class SlotMachine extends Component {
             return (
                 <Animated.View
                     key={i}
-                    style={[styles.slotInner, {height}, overrideStyles.slotInner, {top: values[position]}]}
+                    style={[styles.slotInner, {height}, overrideStyles.slotInner, {transform: [{translateY: values[position]}]} ]}
                 >
                     {content}
                 </Animated.View>

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ export default class SlotMachine extends Component {
             initialAnimation: true,
             styles: {},
             renderTextContent: (currentChar) => currentChar,
-	    useNativeDriver: true,
+	        useNativeDriver: false,
         };
     }
 
@@ -101,7 +101,7 @@ export default class SlotMachine extends Component {
             return;
         }
         this.text = newProps.text;
-        const {range, duration} = newProps;
+        const {range, duration, useNativeDriver} = newProps;
         const easing = Easing.inOut(Easing.ease);
         const paddedStr = this.getPaddedString(newProps);
         const newValues = this.getAdjustedAnimationValues(newProps);
@@ -110,7 +110,7 @@ export default class SlotMachine extends Component {
             const newAnimations = paddedStr.split('').map((char, i) => {
                 const index = range.indexOf(char);
                 const animationValue = -1 * (index) * newProps.height;
-                return Animated.timing(this.state.values[i], {toValue: animationValue, duration, easing, useNativeDriver: this.props.useNativeDriver});
+                return Animated.timing(this.state.values[i], {toValue: animationValue, duration, easing, useNativeDriver: useNativeDriver});
             });
             Animated.parallel(newAnimations).start();
         });
@@ -187,12 +187,12 @@ export default class SlotMachine extends Component {
 
     startInitialAnimation() {
         const {values} = this.state;
-        const {duration, slotInterval} = this.props;
+        const {duration, slotInterval, useNativeDriver} = this.props;
         const easing = Easing.inOut(Easing.ease);
 
         const animations = values.map((value, i) => {
             const animationDuration = duration - (values.length - 1 - i) * slotInterval;
-            return Animated.timing(value, {toValue: 0, duration: animationDuration, easing, useNativeDriver: this.props.useNativeDriver});
+            return Animated.timing(value, {toValue: 0, duration: animationDuration, easing, useNativeDriver: useNativeDriver});
         });
 
         Animated.parallel(animations).start(() => {

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ export default class SlotMachine extends Component {
             initialAnimation: true,
             styles: {},
             renderTextContent: (currentChar) => currentChar,
+			useNativeDriver: false,
         };
     }
 
@@ -109,7 +110,7 @@ export default class SlotMachine extends Component {
             const newAnimations = paddedStr.split('').map((char, i) => {
                 const index = range.indexOf(char);
                 const animationValue = -1 * (index) * newProps.height;
-                return Animated.timing(this.state.values[i], {toValue: animationValue, duration, easing});
+                return Animated.timing(this.state.values[i], {toValue: animationValue, duration, easing, useNativeDriver: this.props.useNativeDriver});
             });
             Animated.parallel(newAnimations).start();
         });
@@ -191,7 +192,7 @@ export default class SlotMachine extends Component {
 
         const animations = values.map((value, i) => {
             const animationDuration = duration - (values.length - 1 - i) * slotInterval;
-            return Animated.timing(value, {toValue: 0, duration: animationDuration, easing});
+            return Animated.timing(value, {toValue: 0, duration: animationDuration, easing, useNativeDriver: this.props.useNativeDriver});
         });
 
         Animated.parallel(animations).start(() => {


### PR DESCRIPTION
Issue related: https://github.com/atlanteh/react-native-slot-machine/issues/5

Changed top layout animation to translateY and added useNativeDriver.
Default to true as it's way better.